### PR TITLE
Remove touchstart and touchend event on unmount

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -66,7 +66,8 @@ class Range extends React.Component<IProps> {
   componentWillUnmount() {
     window.removeEventListener('resize', this.schdOnWindowResize);
     document.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
-    document.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
+    document.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
+    document.removeEventListener('touchend', this.schdOnEnd as any);
   }
 
   getOffsets = () => {


### PR DESCRIPTION
This PR is related to this issue : https://github.com/tajo/react-range/issues/18
Since the component updated the state after the unmount (resulting to a no-op warning) I removed the touchend event as well.