### PR TITLE
Invoke onFinalChange() within onEnd()

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -328,6 +328,8 @@ class Range extends React.Component<IProps> {
     document.removeEventListener('touchup', this.schdOnEnd);
     document.removeEventListener('touchcancel', this.schdOnEnd);
     this.setState({ draggedThumbIndex: -1 });
+    const { values, onFinalChange } = this.props;
+    onFinalChange(values);
   };
 
   render() {


### PR DESCRIPTION
Allows a user to pass their own `onFinalChange()` property into react-range, which is called when value is 'committed'. This is useful for users who need to send an AJAX request to an API on only the final change.