### PR TITLE
onDragEnd event, when user finished selecting value

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -16,6 +16,7 @@ import Labeled from '../examples/Labeled';
 import LabeledTwoThumbs from '../examples/LabeledTwoThumbs';
 import LabeledMerge from '../examples/LabeledMerge';
 import LabeledMergeSkinny from '../examples/LabeledMergeSkinny';
+import FinalChangeEvent from '../examples/FinalChangeEvent';
 
 storiesOf('Range', module)
   .add('Basic', () => <Basic />)
@@ -33,4 +34,5 @@ storiesOf('Range', module)
   .add('Labeled', () => <Labeled />)
   .add('Labeled two thumbs', () => <LabeledTwoThumbs/>)
   .add('Merging labels', () => <LabeledMerge />)
-  .add('Merging labels skinny', () => <LabeledMergeSkinny />);
+  .add('Merging labels skinny', () => <LabeledMergeSkinny />)
+  .add('onFinalChange event', () => <FinalChangeEvent />);

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ onChange: (values: number[]) => void;
 
 Called when a thumb is moved, provides new `values`.
 
+### onDragEnd
+
+```ts
+onDragEnd: (values: number[]) => void;
+```
+
+Called when a drag is finished, provides current `values`.
+
 ### min (optional)
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ onChange: (values: number[]) => void;
 
 Called when a thumb is moved, provides new `values`.
 
-### onDragEnd
+### onFinalChange
 
 ```ts
-onDragEnd: (values: number[]) => void;
+onFinalChange: (values: number[]) => void;
 ```
 
-Called when a drag is finished, provides current `values`.
+Called when a change is finished (mouse/touch up, or keyup), provides current `values`. Use this event when you have to make for example ajax request with new values.
 
 ### min (optional)
 

--- a/e2e/final.change.test.ts
+++ b/e2e/final.change.test.ts
@@ -27,3 +27,18 @@ test('dnd the thumb final change event', async () => {
   await untrackMouse(page);
   expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('79.6');
 });
+
+test('keyboard the thumb final change event', async () => {
+  const output = await page.$('#output');
+  const finalOutput = await page.$('#final-output');
+  await trackMouse(page);
+  await page.mouse.click(10, 10);
+  await page.keyboard.press("Tab");
+  await page.keyboard.down('ArrowRight');
+  await page.keyboard.down('ArrowRight');
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.0');
+  expect(await page.evaluate(e => e.textContent, output)).toBe('50.2');
+  await page.keyboard.up('ArrowRight');
+  await untrackMouse(page);
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.2');
+});

--- a/e2e/final.change.test.ts
+++ b/e2e/final.change.test.ts
@@ -25,6 +25,7 @@ test('dnd the thumb final change event', async () => {
   expect(await page.evaluate(e => e.textContent, output)).toBe('79.6');
   await page.mouse.up();
   await untrackMouse(page);
+  await page.waitFor(100);
   expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('79.6');
 });
 

--- a/e2e/final.change.test.ts
+++ b/e2e/final.change.test.ts
@@ -43,3 +43,19 @@ test('keyboard the thumb final change event', async () => {
   await untrackMouse(page);
   expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.2');
 });
+
+test('keyboard the thumb and press another key final change event', async () => {
+  const output = await page.$('#output');
+  const finalOutput = await page.$('#final-output');
+  await trackMouse(page);
+  await page.mouse.click(10, 10);
+  await page.keyboard.press("Tab");
+  await page.keyboard.down('ArrowRight');
+  await page.keyboard.down('ArrowRight');
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.0');
+  expect(await page.evaluate(e => e.textContent, output)).toBe('50.2');
+  await page.keyboard.press('Tab');
+  await page.keyboard.up('Tab');
+  await untrackMouse(page);
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.2');
+});

--- a/e2e/final.change.test.ts
+++ b/e2e/final.change.test.ts
@@ -1,0 +1,29 @@
+import {
+  Examples,
+  getTestUrl,
+  trackMouse,
+  untrackMouse,
+  addFontStyles
+} from './utils';
+
+jest.setTimeout(10000);
+
+beforeEach(async () => {
+  await page.goto(getTestUrl(Examples.FINAL_CHANGE_EVENT));
+  await page.setViewport({ width: 600, height: 200 });
+  await addFontStyles(page);
+});
+
+test('dnd the thumb final change event', async () => {
+  const output = await page.$('#output');
+  const finalOutput = await page.$('#final-output');
+  await trackMouse(page);
+  await page.mouse.move(300, 80);
+  await page.mouse.down();
+  await page.mouse.move(460, 80);
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('50.0');
+  expect(await page.evaluate(e => e.textContent, output)).toBe('79.6');
+  await page.mouse.up();
+  await untrackMouse(page);
+  expect(await page.evaluate(e => e.textContent, finalOutput)).toBe('79.6');
+});

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -9,6 +9,7 @@ export enum Examples {
   MERGING_LABELS,
   SKINNY_MERGING_LABELS,
   RTL,
+  FINAL_CHANGE_EVENT,
 }
 
 export const getTestUrl = (example: Examples): string => {
@@ -30,6 +31,8 @@ export const getTestUrl = (example: Examples): string => {
       return `http://localhost:${PORT}/iframe.html?path=/story/range--merging-labels-skinny`;
     case Examples.RTL:
       return `http://localhost:${PORT}/iframe.html?path=/story/range--rtl`;
+    case Examples.FINAL_CHANGE_EVENT:
+      return `http://localhost:${PORT}/iframe.html?path=/story/range--onfinalchange-event`;
   }
 };
 

--- a/examples/FinalChangeEvent.tsx
+++ b/examples/FinalChangeEvent.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Range, getTrackBackground } from '../src/index';
+
+const STEP = 0.1;
+const MIN = 0;
+const MAX = 100;
+
+class FinalChangeEvent extends React.Component {
+  state = {
+    values: [50],
+    finalValues: [50],
+  };
+
+  render() {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          flexWrap: 'wrap'
+        }}
+      >
+        <Range
+          values={this.state.values}
+          step={STEP}
+          min={MIN}
+          max={MAX}
+          onChange={values => this.setState({ values })}
+          onFinalChange={values => this.setState({ finalValues: values })}
+          renderTrack={({ props, children }) => (
+            <div
+              onMouseDown={props.onMouseDown}
+              onTouchStart={props.onTouchStart}
+              style={{
+                ...props.style,
+                height: '36px',
+                display: 'flex',
+                width: '100%'
+              }}
+            >
+              <div
+                ref={props.ref}
+                style={{
+                  height: '5px',
+                  width: '100%',
+                  borderRadius: '4px',
+                  background: getTrackBackground({
+                    values: this.state.values,
+                    colors: ['#548BF4', '#ccc'],
+                    min: MIN,
+                    max: MAX
+                  }),
+                  alignSelf: 'center'
+                }}
+              >
+                {children}
+              </div>
+            </div>
+          )}
+          renderThumb={({ props, isDragged }) => (
+            <div
+              {...props}
+              style={{
+                ...props.style,
+                height: '42px',
+                width: '42px',
+                borderRadius: '4px',
+                backgroundColor: '#FFF',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                boxShadow: '0px 2px 6px #AAA'
+              }}
+            >
+              <div
+                style={{
+                  height: '16px',
+                  width: '5px',
+                  backgroundColor: isDragged ? '#548BF4' : '#CCC'
+                }}
+              />
+            </div>
+          )}
+        />
+        <output style={{ marginTop: '30px' }}>
+          <span>
+            onChange value:
+            &nbsp;
+            <span id="output">
+              {this.state.values[0].toFixed(1)}
+            </span>
+          </span>
+          &nbsp;/&nbsp;
+          <span>
+            onFinalChange value:
+            &nbsp;
+            <span id="final-output">
+              {this.state.finalValues[0].toFixed(1)}
+            </span>
+          </span>
+        </output>
+      </div>
+    );
+  }
+}
+
+export default FinalChangeEvent;

--- a/flowtypes/Range.js.flow
+++ b/flowtypes/Range.js.flow
@@ -30,7 +30,7 @@ declare interface IProps {
   disabled?: boolean;
   rtl?: boolean;
   onChange: (values: number[]) => mixed;
-  onDragEnd?: (values: number[]) => mixed;
+  onFinalChange?: (values: number[]) => mixed;
   renderThumb: (params: {
     props: IThumbProps,
     value: number,

--- a/flowtypes/Range.js.flow
+++ b/flowtypes/Range.js.flow
@@ -30,6 +30,7 @@ declare interface IProps {
   disabled?: boolean;
   rtl?: boolean;
   onChange: (values: number[]) => mixed;
+  onDragEnd?: (values: number[]) => mixed;
   renderThumb: (params: {
     props: IThumbProps,
     value: number,

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -16,7 +16,13 @@ import {
 } from './utils';
 import { IProps, Direction } from './types';
 
-class Range extends React.Component<IProps> {
+interface IState {
+  draggedThumbIndex: number;
+  thumbZIndexes: number[];
+  isChanged?: boolean;
+}
+
+class Range extends React.Component<IProps, IState> {
   static defaultProps = {
     step: 1,
     direction: Direction.Right,
@@ -32,7 +38,7 @@ class Range extends React.Component<IProps> {
   schdOnEnd: (e: Event) => void;
   schdOnWindowResize: () => void;
 
-  state = {
+  state: IState = {
     draggedThumbIndex: -1,
     thumbZIndexes: new Array(this.props.values.length).fill(0).map((t, i) => i)
   };
@@ -230,7 +236,8 @@ class Range extends React.Component<IProps> {
     if (['ArrowRight', 'ArrowUp', 'k', 'PageUp'].includes(e.key)) {
       e.preventDefault();
       this.setState({
-        draggedThumbIndex: index
+        draggedThumbIndex: index,
+        isChanged: true
       });
       onChange(
         replaceAt(
@@ -245,7 +252,8 @@ class Range extends React.Component<IProps> {
     } else if (['ArrowLeft', 'ArrowDown', 'j', 'PageDown'].includes(e.key)) {
       e.preventDefault();
       this.setState({
-        draggedThumbIndex: index
+        draggedThumbIndex: index,
+        isChanged: true
       });
       onChange(
         replaceAt(
@@ -263,7 +271,16 @@ class Range extends React.Component<IProps> {
   };
 
   onKeyUp = (e: React.KeyboardEvent) => {
-    this.setState({ draggedThumbIndex: -1 });
+    const { isChanged } = this.state;
+
+    this.setState({
+      draggedThumbIndex: -1,
+      isChanged: false
+    }, () => {
+      if (isChanged && this.props.onDragEnd) {
+        this.props.onDragEnd(this.props.values);
+      }
+    });
   };
 
   onMove = (clientX: number, clientY: number) => {
@@ -327,7 +344,11 @@ class Range extends React.Component<IProps> {
     document.removeEventListener('mouseup', this.schdOnEnd);
     document.removeEventListener('touchup', this.schdOnEnd);
     document.removeEventListener('touchcancel', this.schdOnEnd);
-    this.setState({ draggedThumbIndex: -1 });
+    this.setState({ draggedThumbIndex: -1 }, () => {
+      if (this.props.onDragEnd) {
+        this.props.onDragEnd(this.props.values);
+      }
+    });
   };
 
   render() {

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -281,7 +281,6 @@ class Range extends React.Component<IProps> {
 
   onKeyUp = (e: React.KeyboardEvent) => {
     const { isChanged } = this.state;
-    console.log('keyup', 'isChanged', isChanged);
     this.setState({
       draggedThumbIndex: -1,
       isChanged: false,

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -283,7 +283,6 @@ class Range extends React.Component<IProps> {
     const { isChanged } = this.state;
     this.setState({
       draggedThumbIndex: -1,
-      isChanged: false,
     }, () => {
       if (isChanged) {
         this.fireOnFinalChange();
@@ -358,6 +357,7 @@ class Range extends React.Component<IProps> {
   };
 
   fireOnFinalChange = () => {
+    this.setState({ isChanged: false });
     const { onFinalChange, values } = this.props;
     if (onFinalChange) {
       onFinalChange(values);

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -267,10 +267,11 @@ class Range extends React.Component<IProps> {
   };
 
   onKeyUp = (e: React.KeyboardEvent) => {
+    const eventKey = e.key;
     this.setState({
       draggedThumbIndex: -1
     }, () => {
-      if (INCREASE_KEYS.includes(e.key) || DECREASE_KEYS.includes(e.key)) {
+      if (INCREASE_KEYS.includes(eventKey) || DECREASE_KEYS.includes(eventKey)) {
         const { onFinalChange, values } = this.props;
         if (onFinalChange) {
           onFinalChange(values);

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -16,13 +16,10 @@ import {
 } from './utils';
 import { IProps, Direction } from './types';
 
-interface IState {
-  draggedThumbIndex: number;
-  thumbZIndexes: number[];
-  isChanged?: boolean;
-}
+const INCREASE_KEYS = ['ArrowRight', 'ArrowUp', 'k', 'PageUp'];
+const DECREASE_KEYS = ['ArrowLeft', 'ArrowDown', 'j', 'PageDown'];
 
-class Range extends React.Component<IProps, IState> {
+class Range extends React.Component<IProps> {
   static defaultProps = {
     step: 1,
     direction: Direction.Right,
@@ -38,7 +35,7 @@ class Range extends React.Component<IProps, IState> {
   schdOnEnd: (e: Event) => void;
   schdOnWindowResize: () => void;
 
-  state: IState = {
+  state = {
     draggedThumbIndex: -1,
     thumbZIndexes: new Array(this.props.values.length).fill(0).map((t, i) => i)
   };
@@ -233,11 +230,11 @@ class Range extends React.Component<IProps, IState> {
     const index = this.getTargetIndex(e.nativeEvent);
     const inverter = rtl ? -1 : 1;
     if (index === -1) return;
-    if (['ArrowRight', 'ArrowUp', 'k', 'PageUp'].includes(e.key)) {
+
+    if (INCREASE_KEYS.includes(e.key)) {
       e.preventDefault();
       this.setState({
-        draggedThumbIndex: index,
-        isChanged: true
+        draggedThumbIndex: index
       });
       onChange(
         replaceAt(
@@ -249,11 +246,10 @@ class Range extends React.Component<IProps, IState> {
           )
         )
       );
-    } else if (['ArrowLeft', 'ArrowDown', 'j', 'PageDown'].includes(e.key)) {
+    } else if (DECREASE_KEYS.includes(e.key)) {
       e.preventDefault();
       this.setState({
-        draggedThumbIndex: index,
-        isChanged: true
+        draggedThumbIndex: index
       });
       onChange(
         replaceAt(
@@ -271,14 +267,14 @@ class Range extends React.Component<IProps, IState> {
   };
 
   onKeyUp = (e: React.KeyboardEvent) => {
-    const { isChanged } = this.state;
-
     this.setState({
-      draggedThumbIndex: -1,
-      isChanged: false
+      draggedThumbIndex: -1
     }, () => {
-      if (isChanged && this.props.onDragEnd) {
-        this.props.onDragEnd(this.props.values);
+      if (INCREASE_KEYS.includes(e.key) || DECREASE_KEYS.includes(e.key)) {
+        const { onFinalChange, values } = this.props;
+        if (onFinalChange) {
+          onFinalChange(values);
+        }
       }
     });
   };
@@ -345,8 +341,9 @@ class Range extends React.Component<IProps, IState> {
     document.removeEventListener('touchup', this.schdOnEnd);
     document.removeEventListener('touchcancel', this.schdOnEnd);
     this.setState({ draggedThumbIndex: -1 }, () => {
-      if (this.props.onDragEnd) {
-        this.props.onDragEnd(this.props.values);
+      const { onFinalChange, values } = this.props;
+      if (onFinalChange) {
+        onFinalChange(values);
       }
     });
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface IProps {
   disabled: boolean;
   rtl: boolean,
   onChange: (values: number[]) => void;
+  onDragEnd: (values: number[]) => void;
   renderThumb: (params: {
     props: IThumbProps;
     value: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface IProps {
   disabled: boolean;
   rtl: boolean,
   onChange: (values: number[]) => void;
-  onDragEnd?: (values: number[]) => void;
+  onFinalChange?: (values: number[]) => void;
   renderThumb: (params: {
     props: IThumbProps;
     value: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface IProps {
   disabled: boolean;
   rtl: boolean,
   onChange: (values: number[]) => void;
-  onDragEnd: (values: number[]) => void;
+  onDragEnd?: (values: number[]) => void;
   renderThumb: (params: {
     props: IThumbProps;
     value: number;


### PR DESCRIPTION
This improves #32 PR and relates to #30 
Event fired in these cases:
1. When a user ends dragging (mouse/touch)
2. Keyboard key ups

But I may forget some cases.
I saw, that you prefer `onDragEnd` name. But I guess the event should be fired also when a user makes a single click. And in this case, I think this event should have a different name.
What do you think?

- [x] TypeScript types
- [x] Flow types
- [x] Readme