### PR TITLE
Limit max z-index value by number of thumbs

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -207,12 +207,12 @@ class Range extends React.Component<IProps> {
     }
     this.setState({
       draggedThumbIndex: index,
-      thumbZIndexes: this.state.thumbZIndexes.map((t, i) =>
-        i === index &&
-        this.state.thumbZIndexes[i] !== Math.max(...this.state.thumbZIndexes)
-          ? Math.max(...this.state.thumbZIndexes) + 1
-          : this.state.thumbZIndexes[i]
-      )
+      thumbZIndexes: this.state.thumbZIndexes.map((t, i) => {
+        if (i === index) {
+          return Math.max(...this.state.thumbZIndexes);
+        }
+        return t <= this.state.thumbZIndexes[index] ? t : t - 1;
+      })
     });
   };
 


### PR DESCRIPTION
This PR fix my issue #42 
With this fix, you will be sure that the maximum z-index will not be greater than the total number of thumbs.