### PR TITLE
Bind events to Range element, not document

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -51,12 +51,14 @@ class Range extends React.Component<IProps> {
 
   componentDidMount() {
     window.addEventListener('resize', this.schdOnWindowResize);
-    document.addEventListener('touchstart', this.onMouseOrTouchStart as any, {
+
+    this.trackRef.current.addEventListener('touchstart', this.onMouseOrTouchStart as any, {
       passive: false
     });
-    document.addEventListener('mousedown', this.onMouseOrTouchStart as any, {
+    this.trackRef.current.addEventListener('mousedown', this.onMouseOrTouchStart as any, {
       passive: false
     });
+
     !this.props.allowOverlap && checkInitialOverlap(this.props.values);
     this.props.values.forEach(value =>
       checkBoundaries(value, this.props.min, this.props.max)
@@ -70,9 +72,10 @@ class Range extends React.Component<IProps> {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.schdOnWindowResize);
-    document.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
-    document.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
-    document.removeEventListener('touchend', this.schdOnEnd as any);
+
+    this.trackRef.current.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
+    this.trackRef.current.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
+    this.trackRef.current.removeEventListener('touchend', this.schdOnEnd as any);
   }
 
   getOffsets = () => {
@@ -148,17 +151,17 @@ class Range extends React.Component<IProps> {
 
   addTouchEvents = (e: TouchEvent) => {
     e.preventDefault();
-    document.addEventListener('touchmove', this.schdOnTouchMove, {
+    this.trackRef.current.addEventListener('touchmove', this.schdOnTouchMove, {
       passive: false
     });
-    document.addEventListener('touchend', this.schdOnEnd);
-    document.addEventListener('touchcancel', this.schdOnEnd);
+    this.trackRef.current.addEventListener('touchend', this.schdOnEnd);
+    this.trackRef.current.addEventListener('touchcancel', this.schdOnEnd);
   };
 
   addMouseEvents = (e: MouseEvent) => {
     e.preventDefault();
-    document.addEventListener('mousemove', this.schdOnMouseMove);
-    document.addEventListener('mouseup', this.schdOnEnd);
+    this.trackRef.current.addEventListener('mousemove', this.schdOnMouseMove);
+    this.trackRef.current.addEventListener('mouseup', this.schdOnEnd);
   };
 
   onMouseDownTrack = (e: React.MouseEvent) => {
@@ -346,11 +349,14 @@ class Range extends React.Component<IProps> {
 
   onEnd = (e: Event) => {
     e.preventDefault();
-    document.removeEventListener('mousemove', this.schdOnMouseMove);
-    document.removeEventListener('touchmove', this.schdOnTouchMove);
-    document.removeEventListener('mouseup', this.schdOnEnd);
-    document.removeEventListener('touchup', this.schdOnEnd);
-    document.removeEventListener('touchcancel', this.schdOnEnd);
+    if (this.trackRef.current) {
+      this.trackRef.current.removeEventListener('mousemove', this.schdOnMouseMove);
+      this.trackRef.current.removeEventListener('touchmove', this.schdOnTouchMove);
+      this.trackRef.current.removeEventListener('mouseup', this.schdOnEnd);
+      this.trackRef.current.removeEventListener('touchup', this.schdOnEnd);
+      this.trackRef.current.removeEventListener('touchcancel', this.schdOnEnd);
+    }
+
     this.setState({ draggedThumbIndex: -1 }, () => {
       this.fireOnFinalChange();
     });

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -349,13 +349,12 @@ class Range extends React.Component<IProps> {
 
   onEnd = (e: Event) => {
     e.preventDefault();
-    if (this.trackRef.current) {
-      this.trackRef.current.removeEventListener('mousemove', this.schdOnMouseMove);
-      this.trackRef.current.removeEventListener('touchmove', this.schdOnTouchMove);
-      this.trackRef.current.removeEventListener('mouseup', this.schdOnEnd);
-      this.trackRef.current.removeEventListener('touchup', this.schdOnEnd);
-      this.trackRef.current.removeEventListener('touchcancel', this.schdOnEnd);
-    }
+
+    this.trackRef.current.removeEventListener('mousemove', this.schdOnMouseMove);
+    this.trackRef.current.removeEventListener('touchmove', this.schdOnTouchMove);
+    this.trackRef.current.removeEventListener('mouseup', this.schdOnEnd);
+    this.trackRef.current.removeEventListener('touchup', this.schdOnEnd);
+    this.trackRef.current.removeEventListener('touchcancel', this.schdOnEnd);
 
     this.setState({ draggedThumbIndex: -1 }, () => {
       this.fireOnFinalChange();

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -52,12 +52,14 @@ class Range extends React.Component<IProps> {
   componentDidMount() {
     window.addEventListener('resize', this.schdOnWindowResize);
 
-    this.trackRef.current.addEventListener('touchstart', this.onMouseOrTouchStart as any, {
-      passive: false
-    });
-    this.trackRef.current.addEventListener('mousedown', this.onMouseOrTouchStart as any, {
-      passive: false
-    });
+    if (this.trackRef.current) {
+      this.trackRef.current.addEventListener('touchstart', this.onMouseOrTouchStart as any, {
+        passive: false
+      });
+      this.trackRef.current.addEventListener('mousedown', this.onMouseOrTouchStart as any, {
+        passive: false
+      });
+    }
 
     !this.props.allowOverlap && checkInitialOverlap(this.props.values);
     this.props.values.forEach(value =>
@@ -73,9 +75,11 @@ class Range extends React.Component<IProps> {
   componentWillUnmount() {
     window.removeEventListener('resize', this.schdOnWindowResize);
 
-    this.trackRef.current.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
-    this.trackRef.current.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
-    this.trackRef.current.removeEventListener('touchend', this.schdOnEnd as any);
+    if (this.trackRef.current) {
+      this.trackRef.current.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
+      this.trackRef.current.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
+      this.trackRef.current.removeEventListener('touchend', this.schdOnEnd as any);
+    }
   }
 
   getOffsets = () => {
@@ -151,17 +155,23 @@ class Range extends React.Component<IProps> {
 
   addTouchEvents = (e: TouchEvent) => {
     e.preventDefault();
-    this.trackRef.current.addEventListener('touchmove', this.schdOnTouchMove, {
-      passive: false
-    });
-    this.trackRef.current.addEventListener('touchend', this.schdOnEnd);
-    this.trackRef.current.addEventListener('touchcancel', this.schdOnEnd);
+
+    if (this.trackRef.current) {
+      this.trackRef.current.addEventListener('touchmove', this.schdOnTouchMove, {
+        passive: false
+      });
+      this.trackRef.current.addEventListener('touchend', this.schdOnEnd);
+      this.trackRef.current.addEventListener('touchcancel', this.schdOnEnd);
+    }
   };
 
   addMouseEvents = (e: MouseEvent) => {
     e.preventDefault();
-    this.trackRef.current.addEventListener('mousemove', this.schdOnMouseMove);
-    this.trackRef.current.addEventListener('mouseup', this.schdOnEnd);
+
+    if (this.trackRef.current) {
+      this.trackRef.current.addEventListener('mousemove', this.schdOnMouseMove);
+      this.trackRef.current.addEventListener('mouseup', this.schdOnEnd);
+    }
   };
 
   onMouseDownTrack = (e: React.MouseEvent) => {
@@ -350,11 +360,13 @@ class Range extends React.Component<IProps> {
   onEnd = (e: Event) => {
     e.preventDefault();
 
-    this.trackRef.current.removeEventListener('mousemove', this.schdOnMouseMove);
-    this.trackRef.current.removeEventListener('touchmove', this.schdOnTouchMove);
-    this.trackRef.current.removeEventListener('mouseup', this.schdOnEnd);
-    this.trackRef.current.removeEventListener('touchup', this.schdOnEnd);
-    this.trackRef.current.removeEventListener('touchcancel', this.schdOnEnd);
+    if (this.trackRef.current) {
+      this.trackRef.current.removeEventListener('mousemove', this.schdOnMouseMove);
+      this.trackRef.current.removeEventListener('touchmove', this.schdOnTouchMove);
+      this.trackRef.current.removeEventListener('mouseup', this.schdOnEnd);
+      this.trackRef.current.removeEventListener('touchup', this.schdOnEnd);
+      this.trackRef.current.removeEventListener('touchcancel', this.schdOnEnd);
+    }
 
     this.setState({ draggedThumbIndex: -1 }, () => {
       this.fireOnFinalChange();


### PR DESCRIPTION
It seems `touchend` keeps firing when you've dragged the range slider once on a touch device, and then just tab/touch somewhere else in your document/website. This messes up logic that depends on `onFinalChange`, as it keeps firing when the user taps/clicks on some other elements in the page. 

Probably because all handlers[ are bound to the `document`](https://github.com/tajo/react-range/blob/fc2590b484a29d71d6a7a33cdedda25efbd87e18/src/Range.tsx#L52).

This PR just binds the handlers to the Range element, fixing the problem i'm having. Tested the PR locally with storybook, and all seems to be working like it should. Including keyboard, touch and click events.

Also tested the PR changes with my own project successfully.

Problem:
![ezgif-2-31d3af4416d9](https://user-images.githubusercontent.com/5155373/66759190-0f46ff80-eea0-11e9-87a3-5c621760cd34.gif)
