### PR TITLE
Add missing step arg to useThumbOverlap type definition

### DIFF
--- a/flowtypes/utils.js.flow
+++ b/flowtypes/utils.js.flow
@@ -6,13 +6,14 @@ declare export function getTrackBackground(params: {
   max: number,
   values: number[],
   colors: string[],
-  direction?: string;
-  rtl?: boolean,
+  direction?: string,
+  rtl?: boolean
 }): string;
 
 declare export function useThumbOverlap(
   rangeRef: Range | null,
   values: number[],
   index: number,
-  separator?: string,
+  step?: number,
+  separator?: string
 ): mixed[];


### PR DESCRIPTION
Add step arg to useThumbOverlap type definition. 

A followup to #54 - This should have been included in that PR. 