### PR TITLE
Remove "divisible by step" warning

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -47,10 +47,6 @@ class Range extends React.Component<IProps> {
     this.schdOnTouchMove = schd(this.onTouchMove);
     this.schdOnEnd = schd(this.onEnd);
     this.schdOnWindowResize = schd(this.onWindowResize);
-
-    if ((props.max - props.min) % props.step !== 0) {
-      console.warn('The difference of `max` and `min` must be divisible by `step`');
-    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
This warning works fine for whole numbers but can incorrectly warn when using decimals. This is observable in the Storybook on the Basic example. I came across it using the slider for a volume control, where the step is 0.1, between a min and max of 0 and 1. You can see the issue by doing the following in a terminal:
```
node -p "1 % 0.1"
> 0.09999999999999995
```
The value is `!==` 0, but we all know 1 is divisible by 0.1.

The warning doesn't seem hugely valuable imo, so am suggesting just removing it?