### PR TITLE
Improved checking for divisible step

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -12,7 +12,8 @@ import {
   voidFn,
   isVertical,
   assertUnreachable,
-  isTouchEvent
+  isTouchEvent,
+  isStepDivisible
 } from './utils';
 import { IProps, Direction } from './types';
 
@@ -48,10 +49,7 @@ class Range extends React.Component<IProps> {
     this.schdOnEnd = schd(this.onEnd);
     this.schdOnWindowResize = schd(this.onWindowResize);
 
-    if (
-      (props.max - props.min) % props.step !== 0 &&
-      Number.isInteger(props.step)
-    ) {
+    if (!isStepDivisible(props.min, props.max, props.step)) {
       console.warn(
         'The difference of `max` and `min` must be divisible by `step`'
       );
@@ -74,7 +72,7 @@ class Range extends React.Component<IProps> {
     translateThumbs(this.getThumbs(), this.getOffsets(), this.props.rtl);
 
     values.forEach(value => {
-      if ((value - min) % step && Number.isInteger(step)) {
+      if (!isStepDivisible(min, value, step)) {
         console.warn(
           'The `values` property is in conflict with the current `step`, `min` and `max` properties. Please provide values that are accessible using the min, max an step values'
         );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,7 +6,8 @@ import {
   checkInitialOverlap,
   replaceAt,
   getTrackBackground,
-  getStepDecimals
+  getStepDecimals,
+  isStepDivisible
 } from './utils';
 import { Direction } from './types';
 
@@ -55,6 +56,21 @@ test('isVertical', () => {
   expect(isVertical(Direction.Left)).toBeFalsy();
   expect(isVertical(Direction.Right)).toBeFalsy();
 });
+
+test('isStepDivisible', () => {
+  expect(isStepDivisible(0, 1, 0.1)).toEqual(true);
+  expect(isStepDivisible(0, 100, 0.1)).toEqual(true);
+  expect(isStepDivisible(0, 10, 1)).toEqual(true);
+  expect(isStepDivisible(0, 10, 10)).toEqual(true);
+  expect(isStepDivisible(0, 10, 2.5)).toEqual(true);
+  expect(isStepDivisible(10, 20, 2.5)).toEqual(true);
+  expect(isStepDivisible(10, 20, 5)).toEqual(true);
+
+  expect(isStepDivisible(0, 1, 0.3)).toEqual(false);
+  expect(isStepDivisible(0, 35, 6)).toEqual(false);
+  expect(isStepDivisible(0, 10, 20)).toEqual(false);
+  expect(isStepDivisible(0, 10, 0)).toEqual(false);
+})
 
 test('checkBoundaries', () => {
   expect(() => checkBoundaries(-10, 0, 100)).toThrow(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,11 @@ export function isTouchEvent(event: TouchEvent & MouseEvent) {
   );
 }
 
+export function isStepDivisible(min: number, max: number, step: number): boolean {
+  const res = (max - min) / step;
+  return parseInt(res.toString(), 10) === res;
+}
+
 export function normalizeValue(
   value: number,
   index: number,


### PR DESCRIPTION
Following on from [previous suggestion](https://github.com/tajo/react-range/pull/60) of just removing the check, this PR improves the checking by making it work with decimals as well as whole numbers. Have also moved the calculation out to a separate util which allows some unit tests to cover it.