### PR TITLE
Fix IE11 issues - eventlistener not removed, getPaddingAndBorder issue

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -87,8 +87,11 @@ class Range extends React.Component<IProps> {
   }
 
   componentWillUnmount() {
+    const options: AddEventListenerOptions = {
+      passive: false
+    };
     window.removeEventListener('resize', this.schdOnWindowResize);
-    document.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
+    document.removeEventListener('mousedown', this.onMouseOrTouchStart as any, options);
     document.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
     document.removeEventListener('touchend', this.schdOnEnd as any);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,10 +94,10 @@ export function getMargin(element: Element) {
 export function getPaddingAndBorder(element: Element) {
   const style = window.getComputedStyle(element);
   return {
-    top: parseInt(style['padding-top' as any], 10) + parseInt(style['border-top' as any], 10),
-    bottom: parseInt(style['padding-bottom' as any], 10) + parseInt(style['border-bottom' as any], 10),
-    left: parseInt(style['padding-left' as any], 10) + parseInt(style['border-left' as any], 10),
-    right: parseInt(style['padding-right' as any], 10) + parseInt(style['border-right' as any], 10),
+    top: parseInt(style['padding-top' as any], 10) + parseInt(style['border-top-width' as any], 10),
+    bottom: parseInt(style['padding-bottom' as any], 10) + parseInt(style['border-bottom-width' as any], 10),
+    left: parseInt(style['padding-left' as any], 10) + parseInt(style['border-left-width' as any], 10),
+    right: parseInt(style['padding-right' as any], 10) + parseInt(style['border-right-width' as any], 10),
   };
 }
 


### PR DESCRIPTION
Due to IE11 inconsistencies, it doesn't remove the mousedown eventlistener without passing in the option that was added in addEventListener.

IE11 also returning NaN when attempting to parseInt border property (since it returns something like: "0px none rgb(0, 0, 0)"). Updated to border-width.
