### PR TITLE
Make optional props actually optional in typescript

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,13 +10,13 @@ export interface ITrackBackground {
 }
 export interface IProps {
   values: number[];
-  min: number;
-  max: number;
-  step: number;
-  direction: Direction;
-  allowOverlap: boolean;
-  disabled: boolean;
-  rtl: boolean,
+  min?: number;
+  max?: number;
+  step?: number;
+  direction?: Direction;
+  allowOverlap?: boolean;
+  disabled?: boolean;
+  rtl?: boolean,
   onChange: (values: number[]) => void;
   onFinalChange?: (values: number[]) => void;
   renderThumb: (params: {


### PR DESCRIPTION
Hi there! Thanks for the nice and concise library.
I've been using it in my typescript project and found that some of the optional props are marked as required in the typescript `IProps` type. So here is the small PR which makes them optional so my JetBrains IDEA won't complain about me not passing them