### PR TITLE
Add guard for accessing innerText

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,6 +193,7 @@ const getThumbWidth = (
          * to that individual Thumb value in order to grab the true width.
          */
         if (
+          (el as HTMLElement).innerText &&
           (el as HTMLElement).innerText.includes(separator) &&
           el.childElementCount === 0
         ) {


### PR DESCRIPTION
There is a possibility the innerText does not exist on the element.