### PR TITLE
fix(utils): use removeChild() instead of remove()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-range",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Range input. Slides in all directions.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -202,7 +202,7 @@ const getThumbWidth = (
           elClone.style.visibility = 'hidden';
           document.body.appendChild(elClone);
           elWidth = Math.ceil(elClone.getBoundingClientRect().width);
-          elClone.remove();
+          document.body.removeChild(elClone);
         }
         return elWidth > width ? elWidth : width;
       },


### PR DESCRIPTION
Following up on Leyan's fix, as there was one more non-IE-friendly call in that function