### PR TITLE
Guard window usage

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -53,7 +53,7 @@ class Range extends React.Component<IProps> {
     this.thumbRefs = props.values.map(() => React.createRef<HTMLElement>());
 
     // @ts-ignore
-    this.resizeObserver = (window.ResizeObserver)
+    this.resizeObserver = (window && window.ResizeObserver)
       // @ts-ignore
       ? new window.ResizeObserver(this.schdOnResize)
       : {


### PR DESCRIPTION
SSR breaking on 1.6.4 due to unguarded `window` usage.