### PR TITLE
add customCursor override property

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ values.length + 1 === colors.length;
 
 That's because **one thumb** (one value) splits the track into **two segments**, so you need **two colors**.
 
+## customCursor
+
+```ts
+customCursor: boolean | string;
+```
+
+By default the cursor style is dynamically updated to reflect interaction e.g. grabbing, etc. This behaviour can be overruled with the `customCursor` property.
+
+Use [a valid css cursor value](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) to consistently present a single `cursor` style. Default is `false`.
+
 ## Motivation
 
 There is a native [input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range) solution:

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface IProps {
   draggableTrack: boolean;
   disabled: boolean;
   rtl: boolean;
+  customCursor: boolean | string;
   onChange: (values: number[]) => void;
   onFinalChange?: (values: number[]) => void;
   renderMark?: (params: {


### PR DESCRIPTION
The Spotify app volume control UI doesn't rely on the cursor change affordance, instead relying on the visibility of the rangeThumb and the track colour. I found the dynamic cursor styling injected by `react-range` to be problematic when attempting to implement this specific behaviour. 

The best, lightest suggestion I have is to add a new property onto the Range component which would act as an override for this dynamically injected, inline cursor styling. Hopefully this brings this great component a little closer to being entirely 'unopinionated' :-)

**Spotify App - target UI**
![SpotifyAppCursor](https://user-images.githubusercontent.com/1751927/95677928-fc553100-0bc0-11eb-9368-f9f777488e7d.gif)

**Problematic cursor clash behaviour**
![ReactRangeCursorClash](https://user-images.githubusercontent.com/1751927/95677929-fd865e00-0bc0-11eb-8874-36df0c4acff6.gif)

**Cursor presentation with customCursor property applied**
![ReactRangeCustomCursor](https://user-images.githubusercontent.com/1751927/95677930-fe1ef480-0bc0-11eb-93ad-747cf0455a81.gif)


* I am pretty new to Typescript so can't entirely stand over the type definition so I'm entirely happy to apply any change requests if you're happy with the concept of the proposed addition?
