### PR TITLE
Fix track background utility for overlapping thumbs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,7 +175,8 @@ export function getTrackBackground({
   } else if (rtl && Direction.Left) {
     direction = Direction.Right;
   }
-  const progress = values.map(value => ((value - min) / (max - min)) * 100);
+  // sort values ascending
+  const progress = values.slice(0).sort((a, b) => a - b).map(value => ((value - min) / (max - min)) * 100);
   const middle = progress.reduce(
     (acc, point, index) =>
       `${acc}, ${colors[index]} ${point}%, ${colors[index + 1]} ${point}%`,


### PR DESCRIPTION
There appears to be a bug in the `getTrackBackground` utility function when using overlapping thumbs. It will generate an invalid gradient since the values are not sorted in ascending order. Here is a demo of the Issue:
![wrong](https://user-images.githubusercontent.com/23213965/95679455-3f200480-0bd3-11eb-80a6-86e57af30d83.png)
The generated invalid gradient is
```css
background: linear-gradient(to right, rgb(204, 204, 204) 0%, rgb(204, 204, 204) 25%, rgb(39, 110, 241) 25%, rgb(39, 110, 241) 16%, rgb(156, 188, 248) 16%, rgb(156, 188, 248) 75%, rgb(204, 204, 204) 75%, rgb(204, 204, 204) 100%)
```
_Notice the percentages_.

With this Pull Request it will sort the `values` array in ascending order before generating the gradient. The output is
![correct](https://user-images.githubusercontent.com/23213965/95679548-ca999580-0bd3-11eb-889c-32cd7d45e4ee.png)
With the correct gradient:
```css
background: linear-gradient(to right, rgb(204, 204, 204) 0%, rgb(204, 204, 204) 16%, rgb(39, 110, 241) 16%, rgb(39, 110, 241) 25%, rgb(156, 188, 248) 25%, rgb(156, 188, 248) 75%, rgb(204, 204, 204) 75%, rgb(204, 204, 204) 100%)
```

To reproduce, you can substitute the following in line 46 inside `examples/AllowOverlap.tsx` 
```jsx
background: getTrackBackground({
  values: this.state.values,
  colors: ['#ccc', '#276EF1', '#9CBCF8', '#ccc'],
  min: MIN,
  max: MAX
}),
```

I'm not sure if this should be added to any existing example, if so please let me know.
