### PR TITLE
empty value support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ es
 yarn-error.log
 storybook-static
 __diff_output__
+
+.idea

--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -26,6 +26,7 @@ import LabeledMergeSkinny from '../examples/LabeledMergeSkinny';
 import LabeledMergeCustom from '../examples/LabeledMergeCustom';
 import FinalChangeEvent from '../examples/FinalChangeEvent';
 import AnimatingContainer from '../examples/AnimatingContainer';
+import EmptyValue from '../examples/EmptyValue';
 // initialize polyfill for :focus-visible pseudo-class
 import '../node_modules/focus-visible/dist/focus-visible.min.js';
 
@@ -61,4 +62,6 @@ storiesOf('Range', module)
   .add('Merging labels skinny', () => <LabeledMergeSkinny />)
   .add('Merging labels custom', () => <LabeledMergeCustom />)
   .add('onFinalChange event', () => <FinalChangeEvent />)
-  .add('Animating container', () => <AnimatingContainer />);
+  .add('Animating container', () => <AnimatingContainer />)
+  .add('Empty values', () => <EmptyValue />
+);

--- a/examples/EmptyValue.tsx
+++ b/examples/EmptyValue.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { Range, getTrackBackground } from '../src/index';
+
+const STEP = 0.1;
+const MIN = 0;
+const MAX = 100;
+
+class Basic extends React.Component {
+  state = {
+    values: []
+  };
+
+  render() {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          flexWrap: 'wrap'
+        }}
+      >
+        <Range
+          values={this.state.values}
+          step={STEP}
+          min={MIN}
+          max={MAX}
+          onChange={values => this.setState({ values })}
+          renderTrack={({ props, children }) => (
+            <div
+              onMouseDown={props.onMouseDown}
+              onTouchStart={props.onTouchStart}
+              style={{
+                ...props.style,
+                height: '36px',
+                display: 'flex',
+                width: '100%'
+              }}
+            >
+              <div
+                ref={props.ref}
+                style={{
+                  height: '5px',
+                  width: '100%',
+                  borderRadius: '4px',
+                  background: getTrackBackground({
+                    values: this.state.values,
+                    colors: ['#548BF4', '#ccc'],
+                    min: MIN,
+                    max: MAX
+                  }),
+                  alignSelf: 'center'
+                }}
+              >
+                {children}
+              </div>
+            </div>
+          )}
+          renderThumb={({ props, isDragged }) => (
+            <div
+              {...props}
+              style={{
+                ...props.style,
+                height: '42px',
+                width: '42px',
+                borderRadius: '4px',
+                backgroundColor: '#FFF',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                boxShadow: '0px 2px 6px #AAA'
+              }}
+            >
+              <div
+                style={{
+                  height: '16px',
+                  width: '5px',
+                  backgroundColor: isDragged ? '#548BF4' : '#CCC'
+                }}
+              />
+            </div>
+          )}
+        />
+        <output style={{ marginTop: '30px' }} id="output">
+          {(this.state.values?.[0] || 0).toFixed(1)}
+        </output>
+      </div>
+    );
+  }
+}
+
+export default Basic;

--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -44,27 +44,33 @@ class Range extends React.Component<IProps> {
   state = {
     draggedTrackPos: [-1, -1],
     draggedThumbIndex: -1,
-    thumbZIndexes: new Array(this.props.values.length).fill(0).map((t, i) => i),
+    thumbZIndexes: new Array(this.props?.values?.length || 0).fill(0).map((t, i) => i),
     isChanged: false,
     markOffsets: []
   };
 
   constructor(props: IProps) {
     super(props);
-    this.numOfMarks = (props.max - props.min) / this.props.step;
+
+    const { min, max, step, values } = props;
+
+    this.numOfMarks = (max - min) / step;
     this.schdOnMouseMove = schd(this.onMouseMove);
     this.schdOnTouchMove = schd(this.onTouchMove);
     this.schdOnEnd = schd(this.onEnd);
-    this.thumbRefs = props.values.map(() => React.createRef<HTMLElement>());
+    this.thumbRefs = Array.isArray(values) ? values.map(() => React.createRef<HTMLElement>()) : [];
+
     for (let i = 0; i < this.numOfMarks + 1; i++) {
       this.markRefs[i] = React.createRef<HTMLElement>();
     }
-    if (!isStepDivisible(props.min, props.max, props.step)) {
+
+    if (!isStepDivisible(min, max, step)) {
       console.warn(
         'The difference of `max` and `min` must be divisible by `step`'
       );
     }
-    if (props.step === 0) {
+
+    if (step === 0) {
       throw new Error('"step" property should be a positive number');
     }
   }


### PR DESCRIPTION
This PR contains the implementation of empty value support. 

It allows to pass empty `values` array and touch or click on slider, thus it will create thumb (+ ref for it) and the first value in `values` array.

After the creation of the first value in `values` array, it will not create new thumbs and values on click/touch events.

Also, I created a storybook for that case called 'EmptyValue'.