### PR TITLE
fix issue with draggable track when min is not zero

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -441,11 +441,11 @@ class Range extends React.Component<IProps> {
       switch (direction) {
         case Direction.Right:
         case Direction.Left:
-          deltaValue = (dX / trackLength) * (max - min) + min;
+          deltaValue = (dX / trackLength) * (max - min);
           break;
         case Direction.Down:
         case Direction.Up:
-          deltaValue = (dY / trackLength) * (max - min) + min;
+          deltaValue = (dY / trackLength) * (max - min);
           break;
         default:
           assertUnreachable(direction);


### PR DESCRIPTION
There seems to be an issue with the draggable track when min is larger or smaller than 0, since we add "min" to the delta value. This creates a jumpy experience (when you click the track) which isn't very nice, see the videos below for details.

In the videos I have changed min to be 20 in both cases. 



https://user-images.githubusercontent.com/22953821/119318416-91e99080-bc79-11eb-9e9b-d37107fb44d2.mp4


https://user-images.githubusercontent.com/22953821/119318418-92822700-bc79-11eb-80b7-f49b0f98c558.mp4

Fixes issue as described in [#140 ](https://github.com/tajo/react-range/issues/140)
