### PR TITLE
Throw the error for step 0 before any usage

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -50,6 +50,10 @@ class Range extends React.Component<IProps> {
 
   constructor(props: IProps) {
     super(props);
+    if (props.step === 0) {
+      throw new Error('"step" property should be a positive number');
+    }
+
     this.numOfMarks = (props.max - props.min) / this.props.step;
     this.schdOnMouseMove = schd(this.onMouseMove);
     this.schdOnTouchMove = schd(this.onTouchMove);
@@ -58,9 +62,7 @@ class Range extends React.Component<IProps> {
     for (let i = 0; i < this.numOfMarks + 1; i++) {
       this.markRefs[i] = React.createRef<HTMLElement>();
     }
-    if (props.step === 0) {
-      throw new Error('"step" property should be a positive number');
-    }
+
   }
 
   componentDidMount() {


### PR DESCRIPTION
A fix was merged for Issue number #101 where it added a throw if step equals 0, unforunately this throw was added in the wrong place, as it does the calculation for numOfMarks and causes a browser lock up before it attempts to throw.