### PR TITLE
fix thumb distance calculation in IE11

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -445,6 +445,6 @@ export const useThumbOverlap = (
  * @param direction - the direction of the track
  */
 function getThumbDistance(thumbEl: Element, clientX: number, clientY: number, direction: Direction) {
-  const { x, y, width, height } = thumbEl.getBoundingClientRect()
-  return isVertical(direction) ? Math.abs(clientY - (y + height / 2)) : Math.abs(clientX - (x + width / 2))
+  const { left, top, width, height } = thumbEl.getBoundingClientRect()
+  return isVertical(direction) ? Math.abs(clientY - (top + height / 2)) : Math.abs(clientX - (left + width / 2))
 }


### PR DESCRIPTION
In IE11 I am unable to use multi-thumb ranges, because the calculation always falls back to the zeroth thumb rendered. Reason: the `x` and `y` properties of `getBoundingClientRect()` are undefined in IE11. See e.g. https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly/x#browser_compatibility

According to specs, `left` and `top` should be equivalent to them, unless someone'd be using negative width/height. See https://www.w3.org/TR/geometry-1/#dom-domrectreadonly-domrect-top

In the meantime, I can use the following polyfill: https://gist.github.com/afterburn/a752b59172751c6900990f659cfb4481 but it's not a perfect solution of course.

Tested RTL locally and it works fine too.