### PR TITLE
Fixed floating point problems in isStepDivisible

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -67,6 +67,7 @@ test('isVertical', () => {
 
 test('isStepDivisible', () => {
   expect(isStepDivisible(0, 1, 0.1)).toEqual(true);
+  expect(isStepDivisible(0.4, 1, 0.1)).toEqual(true);
   expect(isStepDivisible(0, 100, 0.1)).toEqual(true);
   expect(isStepDivisible(0, 10, 1)).toEqual(true);
   expect(isStepDivisible(0, 10, 10)).toEqual(true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,9 @@ export function isTouchEvent(event: TouchEvent & MouseEvent) {
 
 export function isStepDivisible(min: number, max: number, step: number): boolean {
   const res = (max - min) / step;
-  return parseInt(res.toString(), 10) === res;
+  const precision = 8;
+  const roundedRes = Number(res.toFixed(precision));
+  return parseInt(roundedRes.toString(), 10) === roundedRes;
 }
 
 export function normalizeValue(


### PR DESCRIPTION
for this issue : [#110](https://github.com/tajo/react-range/issues/110)

Still had problems with division in isStepDivisible function.
Example:
```
let max=1;
let min=0.4;
let step=0.1;
(max - min) / step
```

returns `5.999999999999999`, so isStepDivisible is false, which is not correct. My proposal resolves this issue using toFixed method with some precision