### PR TITLE
fix trackElement is null when resize window

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -152,8 +152,8 @@ class Range extends React.Component<IProps> {
   getOffsets = () => {
     const { direction, values, min, max } = this.props;
     const trackElement = this.trackRef.current!;
-    const trackRect = trackElement.getBoundingClientRect();
-    const trackPadding = getPaddingAndBorder(trackElement);
+    const trackRect = trackElement ? trackElement.getBoundingClientRect() : undefined;
+    const trackPadding = trackRect ? getPaddingAndBorder(trackElement) : undefined;
     return this.getThumbs().map((thumb, index) => {
       const thumbOffsets = { x: 0, y: 0 };
       const thumbRect = thumb.getBoundingClientRect();


### PR DESCRIPTION
i use react-range in responsive card view.
when parent card width is change is show trackElement is null error.
this change set trackElement and trackPadding to undefined if trackRef is not ready and call getThumbs function.