### PR TITLE
extract param type definitions into own interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,22 +20,28 @@ export interface IProps {
   rtl: boolean;
   onChange: (values: number[]) => void;
   onFinalChange?: (values: number[]) => void;
-  renderMark?: (params: {
-    props: IMarkProps;
-    index: number;
-  }) => React.ReactNode;
-  renderThumb: (params: {
-    props: IThumbProps;
-    value: number;
-    index: number;
-    isDragged: boolean;
-  }) => React.ReactNode;
-  renderTrack: (params: {
-    props: ITrackProps;
-    children: React.ReactNode;
-    isDragged: boolean;
-    disabled: boolean;
-  }) => React.ReactNode;
+  renderMark?: (params: IRenderMarkParams) => React.ReactNode;
+  renderThumb: (params: IRenderThumbParams) => React.ReactNode;
+  renderTrack: (params: IRenderTrackParams) => React.ReactNode;
+}
+
+export interface IRenderMarkParams {
+  props: IMarkProps;
+  index: number;
+}
+
+export interface IRenderThumbParams {
+  props: IThumbProps;
+  value: number;
+  index: number;
+  isDragged: boolean;
+}
+
+export interface IRenderTrackParams {
+  props: ITrackProps;
+  children: React.ReactNode;
+  isDragged: boolean;
+  disabled: boolean;
 }
 
 export interface IThumbProps {


### PR DESCRIPTION
Thank you for providing this helpful utility!

In our project we use typescript and define the `renderThumb` component outside of the jsx template.
Here it would be great to be able to use the type definitions provided by the library:

```tsx
exort const MyComponent () => {
  const renderThumb = (params: IRenderThumbParams) => { // here we want to use the type definition
    // ...
  }

  return (
    <Range
      // ...
      renderThumb={renderThumb}
    />
  )
}



```

