### PR TITLE
Provide narrower tuple type instead of list type for `useThumbOverlap`.

### DIFF
--- a/examples/LabeledMerge.tsx
+++ b/examples/LabeledMerge.tsx
@@ -33,7 +33,7 @@ const ThumbLabel = ({
         borderRadius: '4px',
         backgroundColor: '#548BF4',
         whiteSpace: 'nowrap',
-        ...(style as React.CSSProperties)
+        ...style
       }}
     >
       {labelValue}

--- a/examples/LabeledMergeCustom.tsx
+++ b/examples/LabeledMergeCustom.tsx
@@ -40,7 +40,7 @@ function ThumbLabel({
         borderRadius: '4px',
         backgroundColor: '#548BF4',
         whiteSpace: 'nowrap',
-        ...(labelStyle as React.CSSProperties)
+        ...labelStyle
       }}
     >
       {labelValue}

--- a/examples/LabeledMergeSkinny.tsx
+++ b/examples/LabeledMergeSkinny.tsx
@@ -33,7 +33,7 @@ const ThumbLabel = ({
         borderRadius: '4px',
         backgroundColor: '#548BF4',
         whiteSpace: 'nowrap',
-        ...(style as React.CSSProperties)
+        ...style
       }}
     >
       {labelValue}

--- a/flowtypes/utils.js.flow
+++ b/flowtypes/utils.js.flow
@@ -17,4 +17,4 @@ declare export function useThumbOverlap(
   step?: number,
   separator?: string,
   valueToLabel?: (string) => string
-): mixed[];
+): [string, React.CSSProperties];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Range from './Range';
 import { TThumbOffsets, ITrackBackground, Direction } from './types';
 
@@ -338,7 +338,7 @@ export const useThumbOverlap = (
   step = 0.1,
   separator = ' - ',
   valueToLabel = (value: string): string => value
-) => {
+): [string, React.CSSProperties] => {
   const decimalPlaces = getStepDecimals(step);
   // Create initial label style and value. Label value defaults to thumb value
   const [labelStyle, setLabelStyle] = useState<React.CSSProperties>({});


### PR DESCRIPTION
Eliminates the need for typecasts when using returned styles.